### PR TITLE
Add a mechanism to retry faulty connections

### DIFF
--- a/P3-Tests/P3ClientTest.class.st
+++ b/P3-Tests/P3ClientTest.class.st
@@ -579,6 +579,7 @@ P3ClientTest >> testTimeout [
 	client close.
 	client url: Url.
 	client timeout: 1. "second"
+	client retryCount: 0; retryDelay: 0. "make sure there is no retry waiting"
 	self assert: client isWorking.
 	"The following (sleeping for 0.5 seconds) should just pass successfully"
 	client execute: 'SELECT pg_sleep(0.5)'.

--- a/P3/P3Client.class.st
+++ b/P3/P3Client.class.st
@@ -530,6 +530,14 @@ P3Client >> logResult: result [
 	properties removeKey: #query_started
 ]
 
+{ #category : #'private - logging' }
+P3Client >> logRetryConnection: remaining [
+	(self newLogEvent: P3RetryConnectionEvent)
+		remaining: remaining;
+		delay: self retryDelay;
+		emit
+]
+
 { #category : #'private messages' }
 P3Client >> md5PasswordMessage: salt [
 	"concat('md5', md5(concat(md5(concat(password, username)), random-salt))).
@@ -755,10 +763,11 @@ P3Client >> query: query [
 	Descriptions is a collection of row field description objects, if any.
 	Data is a collection of rows with fully converted field values as objects, if any."
 
-	^ self 
-		ensureConnected;
-		writeQueryMessage: query;
-		runQueryResult
+	^ self withConnection: [
+		self 
+			ensureConnected;
+			writeQueryMessage: query;
+			runQueryResult ]
 ]
 
 { #category : #accessing }
@@ -803,6 +812,38 @@ P3Client >> reset [
 	self clearSession.
 	properties removeAll.
 	converter := nil
+]
+
+{ #category : #accessing }
+P3Client >> retryCount [
+	"Return how many times a reconnection will be tried on a failed connection, the default being 10 times.
+	See also #retryDelay."
+	
+	^ settings at: #retryCount ifAbsentPut: [ 10 ]
+]
+
+{ #category : #'initialize-release' }
+P3Client >> retryCount: count [
+	"Set how many times a reconnection will be tried on a failed connection, the default being 10 times.
+	See also #retryDelay:"
+	
+	^ settings at: #retryCount put: count
+]
+
+{ #category : #accessing }
+P3Client >> retryDelay [
+	"Return the delay after which a reconnection will be tried on a failed connection, the default being 5 seconds.
+	See also #retryCount."
+	
+	^ settings at: #retryDelay ifAbsentPut: [ 5 ]
+]
+
+{ #category : #'initialize-release' }
+P3Client >> retryDelay: seconds [
+	"Set the delay after which a reconnection will be tried on a failed connection, the default being 5 seconds.
+	See also #retryCount:"
+	
+	^ settings at: #retryDelay put: 5
 ]
 
 { #category : #protocol }
@@ -1090,6 +1131,25 @@ P3Client >> verbose: flag [
 	flag
 		ifTrue: [ P3LogEvent logToTranscript ] 
 		ifFalse: [ P3LogEvent stopLoggingToTranscript ]
+]
+
+{ #category : #private }
+P3Client >> withConnection: block [
+	"Execute block, code that will use my conneciton.
+	Handle network errors with a retry/reconnection scheme"
+	
+	^ [ block value "first try" ] 
+		on: NetworkError 
+		do: [ 
+			self close. "first immediate retry"
+			self retryCount to: 1 by: -1 do: [ :remaining | 
+				[ ^ block value ]
+					on: NetworkError 
+					do: [ 
+						self close. "retry after wait"
+						self logRetryConnection: remaining.
+						self retryDelay seconds wait ] ].
+			block value "final unprotected try" ]
 ]
 
 { #category : #'input/output' }

--- a/P3/P3LogEvent.class.st
+++ b/P3/P3LogEvent.class.st
@@ -124,7 +124,8 @@ P3LogEvent >> printOn: stream [
 	timestamp printHMSOn: stream. 
 	stream space.
 	id \\ 1000 printOn: stream base: 10 length: 3 padded: true.
-	stream nextPutAll: ' [P3] '; print: session; space.
+	stream nextPutAll: ' [P3] '.
+	session ifNotNil: [ stream print: session; space ].
 	self printContentsOn: stream
 ]
 

--- a/P3/P3MessageBuffer.class.st
+++ b/P3/P3MessageBuffer.class.st
@@ -48,8 +48,10 @@ P3MessageBuffer >> rawByteBuffer [
 
 { #category : #initialization }
 P3MessageBuffer >> readFrom: readStream [
-	| length |
-	self tag: readStream next asCharacter.
+	| byte length |
+	(byte := readStream next)
+		ifNil: [ ^ ConnectionClosed signal ].
+	self tag: byte asCharacter.
 	length := (self uint32From: readStream) - 4.
 	self initializeForSize: length.
 	length > 0

--- a/P3/P3RetryConnectionEvent.class.st
+++ b/P3/P3RetryConnectionEvent.class.st
@@ -1,0 +1,40 @@
+"
+I am P3RetryConnectionEvent.
+I am a P3LogEvent.
+
+I represent the fact that a PostgreSQL client connection failed and is being retried.
+"
+Class {
+	#name : #P3RetryConnectionEvent,
+	#superclass : #P3LogEvent,
+	#instVars : [
+		'remaining',
+		'delay'
+	],
+	#category : #'P3-Logging'
+}
+
+{ #category : #accessing }
+P3RetryConnectionEvent >> delay [
+	^ delay
+]
+
+{ #category : #accessing }
+P3RetryConnectionEvent >> delay: anObject [
+	delay := anObject
+]
+
+{ #category : #printing }
+P3RetryConnectionEvent >> printContentsOn: stream [
+	stream print: #RetryConnection; space; print: remaining; nextPutAll: ' remaining, after '; print: delay; nextPut: $s
+]
+
+{ #category : #accessing }
+P3RetryConnectionEvent >> remaining [
+	^ remaining
+]
+
+{ #category : #accessing }
+P3RetryConnectionEvent >> remaining: anObject [
+	remaining := anObject
+]


### PR DESCRIPTION
Add P3Client>>#withConnection: with the logic
Use it in P3Client>>#query: only
Add P3Client settings #retryCount and #retryDelay with accessors and defaults
Add P3RetryConnectionEvent for logging
Note that prepared statements currently do not use #withConnection: as they only live for a session and are typically setup at the beginning